### PR TITLE
Fix deprecated InvalidArgumentException in Notifier::prepare()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.4.2] - 2026-08-11
+
+### 🔧 Notification Compatibility Fix
+
+### Fixed
+- **Deprecated Exception in Notifier** (#6): `Notifier::prepare()` now throws `OCP\Notification\UnknownNotificationException` instead of the deprecated plain `InvalidArgumentException` when a notification is not known to this notifier — Nextcloud ≥ 30 logged a deprecation warning on every notifications API poll (e.g. from mobile clients or Unified Push) whenever other apps' notifications were processed
+
+---
+
 ## [1.4.1] - 2026-07-26
 
 ### 🔧 Nextcloud 34 Compatibility, Token Setup Guidance & Release Polish

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -92,7 +92,7 @@ Seamlessly connect your Nextcloud collaboration platform with iTop IT Service Ma
 
 #### Start streamlining your ITSM workflow - Connect iTop with Nextcloud and experience unified IT service management!]]></description>
 
-	<version>1.4.1</version>
+	<version>1.4.2</version>
 	<licence>AGPL-3.0-or-later</licence>
 
 	<author>iTop Integration Team</author>

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -12,13 +12,13 @@
 
 namespace OCA\Itop\Notification;
 
-use InvalidArgumentException;
 use OCA\Itop\AppInfo\Application;
 use OCP\IConfig;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 
 class Notifier implements INotifier {
 
@@ -80,13 +80,13 @@ class Notifier implements INotifier {
 	 * @param INotification $notification
 	 * @param string $languageCode The code of the language that should be used to prepare the notification
 	 * @return INotification
-	 * @throws InvalidArgumentException When the notification was not prepared by a notifier
+	 * @throws UnknownNotificationException When the notification is not known to this notifier
 	 * @since 9.0.0
 	 */
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== 'integration_itop') {
 			// Not my app => throw
-			throw new InvalidArgumentException();
+			throw new UnknownNotificationException();
 		}
 
 		$l = $this->factory->get('integration_itop', $languageCode);
@@ -358,7 +358,7 @@ class Notifier implements INotifier {
 
 			default:
 				// Unknown subject => Unknown notification => throw
-				throw new InvalidArgumentException();
+				throw new UnknownNotificationException();
 		}
 	}
 }


### PR DESCRIPTION
Fixes #6

Nextcloud ≥ 30 expects notifiers to throw `OCP\Notification\UnknownNotificationException` when a notification is not known to them. `Notifier::prepare()` still threw a plain `InvalidArgumentException`, which is deprecated and logged a warning on every notifications API poll whenever other apps' notifications (e.g. Unified Push) were processed.

## Changes
- `lib/Notification/Notifier.php`: throw `UnknownNotificationException` for foreign-app notifications and unknown subjects; updated import and docblock.

No compatibility shim needed: `UnknownNotificationException` exists since NC 30 (our declared min-version) and extends `InvalidArgumentException`, so behavior is unchanged on all supported versions.

## Verification (NC 34.0.2)
- `php -l` clean
- Repeated `GET /ocs/v2.php/apps/notifications/api/v2/notifications` with foreign-app notifications present: deprecation warning no longer appears in `nextcloud.log`
- Injected a real `ticket_status_changed` notification: renders correctly with subject, message, and ticket link